### PR TITLE
Tests: Add UWM fixtures

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install json schema validator
       run: gem install json_schemer
     - name: Run json_schemer against aarkvark fixtures
-      run: find test/fixtures/files/gbl_documents -type f -name "*.json" | xargs json_schemer schema/geoblacklight-schema-aardvark.json
+      run: find test/fixtures/files/** -type f -name "*.json" | xargs json_schemer schema/geoblacklight-schema-aardvark.json
 
   test:
     runs-on: ubuntu-latest

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -169,7 +169,7 @@ class CatalogController < ApplicationController
     config.add_show_field Settings.FIELDS.TEMPORAL_COVERAGE, label: "Temporal Coverage", itemprop: "temporal"
     config.add_show_field Settings.FIELDS.DATE_ISSUED, label: "Date Issued", itemprop: "issued"
     config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: "Spatial Coverage", itemprop: "spatial", link_to_facet: true
-    config.add_show_field Settings.FIELDS.RIGHTS, label: "Rights", itemprop: "rights"
+    config.add_show_field Settings.FIELDS.RIGHTS, label: "Rights", itemprop: "rights", helper_method: :render_html_value
     config.add_show_field Settings.FIELDS.RIGHTS_HOLDER, label: "Rights Holder", itemprop: "rights_holder"
     config.add_show_field Settings.FIELDS.LICENSE, label: "License", itemprop: "license"
     config.add_show_field Settings.FIELDS.ACCESS_RIGHTS, label: "Access Rights", itemprop: "access_rights"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def render_html_value(args)
+    simple_format(Array(args[:value]).flatten.join(' '))
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def render_html_value(args)
-    simple_format(Array(args[:value]).flatten.join(' '))
+    simple_format(Array(args[:value]).flatten.join(" "))
   end
 end

--- a/test/fixtures/files/uwm_documents/DoorCounty_Lighthouses_2010_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/DoorCounty_Lighthouses_2010_BL_Aardvark.json
@@ -1,0 +1,47 @@
+{
+  "dct_title_s": "Lighthouses Door County, Wisconsin 2010",
+  "dct_description_sm": [
+    "This point data layer represents lighthouses for Door County, Wisconsin in 2010. The dataset was originally published by the Door County Land Information Office in 2010."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Door County Land Information Office"
+  ],
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Point data"
+  ],
+  "dcat_theme_sm": [
+    "Structure"
+  ],
+  "dct_temporal_sm": [
+    "2010"
+  ],
+  "dct_issued_s": "2010",
+  "gbl_indexYear_im": [
+    2010
+  ],
+  "dct_spatial_sm": [
+    "Door County",
+    "Wisconsin"
+  ],
+  "locn_geometry": "ENVELOPE(-86.828195, -87.437837, 45.442146, 44.783488)",
+  "dcat_bbox": "ENVELOPE(-87.437837, -86.828195, 45.442146, 44.783488)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>.",
+    "Although this data is being distributed by the American Geographical Society Library at the University of Wisconsin-Milwaukee Libraries, no warranty expressed or implied is made by the University as to the accuracy of the data and related materials. The act of distribution shall not constitute any such warranty, and no responsibility is assumed by the University in the use of this data, or related materials.",
+    "Restricted to distribution to UW-System students, faculty, or staff for educational use.<br/><br/>[Students, faculty, and staff are allowed to make hard-copy maps from the data. Redistribution to other parties for any reason is forbidden.  Any maps, any export image of, or any derivative can not be published over the World Wide Web or redistributed electronically.  Any publication of the maps in hardcopy or other formats must be approved by Door County prior to publication.] - Text from UWM_Dist-Agreement between UWM and Door County 2006. AGSL staff has the distribution agreement on file.<br/>"
+  ],
+  "dct_accessRights_s": "Restricted",
+  "dct_format_s": "Shapefile",
+  "gbl_wxsIdentifier_s": "druid:0E5F7E87-9A40-40EF-B94F-3B53600DAADE",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.uwm.edu/0E5F7E87-9A40-40EF-B94F-3B53600DAADE\",\"http://schema.org/downloadUrl\":\"http://stacks.uwm.edu/file/druid:0E5F7E87-9A40-40EF-B94F-3B53600DAADE/data.zip\"}",
+  "id": "0E5F7E87-9A40-40EF-B94F-3B53600DAADE",
+  "gbl_mdModified_dt": "2023-01-26T21:25:12.4559154Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/MilwaukeeCounty_Cadastral_2020_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/MilwaukeeCounty_Cadastral_2020_BL_Aardvark.json
@@ -1,0 +1,48 @@
+{
+  "dct_title_s": "Cadastral Milwaukee County, Wisconsin 2020",
+  "dct_description_sm": [
+    "These data layers represent cadastral information for Milwaukee County, Wisconsin in 2020. They are feature classes within the feature datatset MilwaukeeCounty_Cadastral_2020 in the geodatabase MilwaukeeCounty_Cadastral_2020.gdb. The geodatabase contains data layers representing cartographic line work, condominiums, certified survey map boundary lines, parcel boundaries, right-of-way boundaries, subdivision boundaries, and hydrographic lines. These data layers contain minimal metadata written by Milwaukee County Land Information Office. The dataset was originally published by the Milwaukee County Land Information Office on January 16, 2020."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Milwaukee County Land Information Office"
+  ],
+  "schema_provider_s": "American Geographical Society Library – UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Line data",
+    "Polygon data"
+  ],
+  "dcat_theme_sm": [
+    "Property"
+  ],
+  "dct_temporal_sm": [
+    "2020"
+  ],
+  "dct_issued_s": "2020",
+  "gbl_indexYear_im": [
+    2020
+  ],
+  "dct_spatial_sm": [
+    "Milwaukee County",
+    "Wisconsin"
+  ],
+  "locn_geometry": "ENVELOPE(-87.805192, -88.170562, 43.294962, 42.838731)",
+  "dcat_bbox": "ENVELOPE(-88.170562, -87.805192, 43.294962, 42.838731)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>.",
+    "Although this data is being distributed by the American Geographical Society Library at the University of Wisconsin-Milwaukee Libraries, no warranty expressed or implied is made by the University as to the accuracy of the data and related materials. The act of distribution shall not<br/>constitute any such warranty, and no responsibility is assumed by the University in the use of this data, or related materials."
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Geodatabase",
+  "gbl_wxsIdentifier_s": "druid:741B7FCC-A337-490A-96C9-2E6B9EE257AB",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.uwm.edu/741B7FCC-A337-490A-96C9-2E6B9EE257AB\",\"http://schema.org/downloadUrl\":\"http://stacks.uwm.edu/file/druid:741B7FCC-A337-490A-96C9-2E6B9EE257AB/data.zip\"}",
+  "id": "741B7FCC-A337-490A-96C9-2E6B9EE257AB",
+  "gbl_mdModified_dt": "2023-01-26T21:30:08.2745003Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/MilwaukeeCounty_MCTSStops_2018_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/MilwaukeeCounty_MCTSStops_2018_BL_Aardvark.json
@@ -1,0 +1,48 @@
+{
+  "dct_title_s": "MCTS Bus Stops Milwaukee County, Wisconsin 2018",
+  "dct_description_sm": [
+    "This point data layer represents the MCTS bus stops for Milwaukee County, Wisconsin in 2018. The dataset was originally published by the Milwaukee County Transit System (MCTS) in 2018."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Milwaukee County Transit System (MCTS)"
+  ],
+  "schema_provider_s": "American Geographical Society Library – UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Point data"
+  ],
+  "dcat_theme_sm": [
+    "Transportation"
+  ],
+  "dct_temporal_sm": [
+    "2018"
+  ],
+  "dct_issued_s": "2018",
+  "gbl_indexYear_im": [
+    2018
+  ],
+  "dct_spatial_sm": [
+    "Milwaukee County",
+    "Wisconsin"
+  ],
+  "locn_geometry": "ENVELOPE(-87.84947, -88.152203, 43.410983, 42.871369)",
+  "dcat_bbox": "ENVELOPE(-88.152203, -87.84947, 43.410983, 42.871369)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>.",
+    "Please see TermsOfUse.htm.",
+    "Although this data is being distributed by the American Geographical Society Library at the University of Wisconsin-Milwaukee Libraries, no warranty expressed or implied is made by the University as to the accuracy of the data and related materials. The act of distribution shall not constitute any such warranty, and no responsibility is assumed by the University in the use of this data, or related materials."
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Shapefile",
+  "gbl_wxsIdentifier_s": "druid:41756DBD-5DAA-4797-9072-5DE4B951CF6F",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.uwm.edu/41756DBD-5DAA-4797-9072-5DE4B951CF6F\",\"http://schema.org/downloadUrl\":\"http://stacks.uwm.edu/file/druid:41756DBD-5DAA-4797-9072-5DE4B951CF6F/data.zip\"}",
+  "id": "41756DBD-5DAA-4797-9072-5DE4B951CF6F",
+  "gbl_mdModified_dt": "2023-01-26T21:30:46.5311101Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/MilwaukeeCounty_NationalElevationDataset_1999_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/MilwaukeeCounty_NationalElevationDataset_1999_BL_Aardvark.json
@@ -1,0 +1,44 @@
+{
+  "dct_title_s": "National Elevation Dataset Milwaukee County, Wisconsin 1999",
+  "dct_description_sm": [
+    "This ArcGrid data layer represents a National Elevation Dataset for Milwaukee County, Wisconsin in 1999. The dataset was originally published by the U.S. Geological Survey in 1999.[The U.S. Geological Survey has developed a National Elevation Dataset (NED). The NED is a seamless mosaic of best-available elevation data. The 7.5-minute elevation data for the conterminous United States are the primary initial source data. In addition to the availability of complete 7.5-minute data, efficient processing methods were developed to filter production artifacts in the existing data, convert to the NAD83 datum, edge-match, and fill slivers of missing data at quadrangle seams. One of the effects of the NED processing steps is a much-improved base of elevation data for calculating slope and hydrologic derivatives. The specifications for the NED 1 arc second and 1/3 arc second data are: Geographic coordinate system Horizontal datum of NAD83, except for AK which is NAD27 Vertical datum of NAVD88, except for AK which is NAVD29 Z units of meters]"
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "U.S. Geological Survey"
+  ],
+  "schema_provider_s": "American Geographical Society Library – UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "dcat_theme_sm": [
+    "Elevation"
+  ],
+  "dct_temporal_sm": [
+    "1999"
+  ],
+  "dct_issued_s": "1999",
+  "gbl_indexYear_im": [
+    1999
+  ],
+  "dct_spatial_sm": [
+    "Milwaukee County",
+    "Wisconsin"
+  ],
+  "locn_geometry": "ENVELOPE(-87.729444, -88.108333, 43.245833, 42.805556)",
+  "dcat_bbox": "ENVELOPE(-88.108333, -87.729444, 43.245833, 42.805556)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>.[None. Acknowledgement of the originating agencies would be appreciated in products derived from these data.]",
+    "Although this data is being distributed by the American Geographical Society Library at the University of Wisconsin-Milwaukee Libraries, no warranty expressed or implied is made by the University as to the accuracy of the data and related materials. The act of distribution shall not constitute any such warranty, and no responsibility is assumed by the University in the use of this data, or related materials.<br/><br/>[Although these data have been processed successfully on a computer system at the U.S. Geological Survey, EROS Data Center, no warranty expressed or implied is made by either regarding the utility of the data on any system, nor shall the act of distribution constitute any such warranty. The USGS will warrant the delivery of this product in computer-readable format and will offer appropriate adjustment of credit when the product is determined unreadable by correctly adjusted computer peripherals, or when the physical medium is delivered in damaged condition. Requests for adjustments of credit must be made within 90 days from the date of this shipment from the ordering site.]"
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Raster Dataset",
+  "gbl_wxsIdentifier_s": "druid:A6E3CABE-9200-461C-A230-D57206B80257",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.uwm.edu/A6E3CABE-9200-461C-A230-D57206B80257\",\"http://schema.org/downloadUrl\":\"http://stacks.uwm.edu/file/druid:A6E3CABE-9200-461C-A230-D57206B80257/data.zip\"}",
+  "id": "A6E3CABE-9200-461C-A230-D57206B80257",
+  "gbl_mdModified_dt": "2023-02-15T15:54:22.353853Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/PortlandMetro_Freeways_2000_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/PortlandMetro_Freeways_2000_BL_Aardvark.json
@@ -1,0 +1,47 @@
+{
+  "dct_title_s": "Freeways Portland Metro, Oregon 2000",
+  "dct_description_sm": [
+    "This line data layer represents freeways for Portland Metro, Oregon in 2000. The dataset was originally published by the Metro Data Resource Center in February 2001."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Metro Data Resource Center"
+  ],
+  "schema_provider_s": "American Geographical Society Library – UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Line data"
+  ],
+  "dcat_theme_sm": [
+    "Transportation"
+  ],
+  "dct_temporal_sm": [
+    "2000-07-15"
+  ],
+  "dct_issued_s": "2001",
+  "gbl_indexYear_im": [
+    2000
+  ],
+  "dct_spatial_sm": [
+    "Portland Metro",
+    "Oregon"
+  ],
+  "locn_geometry": "ENVELOPE(-121.912937, -123.08286, 45.918689, 45.255769)",
+  "dcat_bbox": "ENVELOPE(-123.08286, -121.912937, 45.918689, 45.255769)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>.",
+    "Although this data is being distributed by the American Geographical Society Library at the University of Wisconsin-Milwaukee Libraries, no warranty expressed or implied is made by the University as to the accuracy of the data and related materials. The act of distribution shall not constitute any such warranty, and no responsibility is assumed by the University in the use of this data, or related materials."
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Shapefile",
+  "gbl_wxsIdentifier_s": "druid:C1375F91-C720-4365-BAD3-E1967B04CC3D",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.uwm.edu/C1375F91-C720-4365-BAD3-E1967B04CC3D\",\"http://schema.org/downloadUrl\":\"http://stacks.uwm.edu/file/druid:C1375F91-C720-4365-BAD3-E1967B04CC3D/data.zip\"}",
+  "id": "C1375F91-C720-4365-BAD3-E1967B04CC3D",
+  "gbl_mdModified_dt": "2023-01-26T21:33:12.3933501Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/WaukeshaCounty_DEM_1999_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/WaukeshaCounty_DEM_1999_BL_Aardvark.json
@@ -1,0 +1,44 @@
+{
+  "dct_title_s": "DEM Waukesha County, Wisconsin 1999",
+  "dct_description_sm": [
+    "This ArcGrid data layer represents a digital elevation model (DEM) for Waukesha County, Wisconsin in 1999. The spatial resolution of the dataset is 30 meters. The data set was originally published by the U.S. Geological Survey in 1999."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "U.S. Geological Survey"
+  ],
+  "schema_provider_s": "American Geographical Society Library – UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "dcat_theme_sm": [
+    "Elevation"
+  ],
+  "dct_temporal_sm": [
+    "1999"
+  ],
+  "dct_issued_s": "1999",
+  "gbl_indexYear_im": [
+    1999
+  ],
+  "dct_spatial_sm": [
+    "Waukesha County",
+    "Wisconsin"
+  ],
+  "locn_geometry": "ENVELOPE(-87.992139, -88.638416, 43.257303, 42.743066)",
+  "dcat_bbox": "ENVELOPE(-88.638416, -87.992139, 43.257303, 42.743066)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>.",
+    "Although this data is being distributed by the American Geographical Society Library at the University of Wisconsin-Milwaukee Libraries, no warranty expressed or implied is made by the University as to the accuracy of the data and related materials. The act of distribution shall not constitute any such warranty, and no responsibility is assumed by the University in the use of this data, or related materials."
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Raster Dataset",
+  "gbl_wxsIdentifier_s": "druid:50DD5CD5-0628-457E-A512-154058823528",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.uwm.edu/50DD5CD5-0628-457E-A512-154058823528\",\"http://schema.org/downloadUrl\":\"http://stacks.uwm.edu/file/druid:50DD5CD5-0628-457E-A512-154058823528/data.zip\"}",
+  "id": "50DD5CD5-0628-457E-A512-154058823528",
+  "gbl_mdModified_dt": "2023-02-15T15:54:22.4756108Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/Wisconsin_IceAgeTrail_2019_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/Wisconsin_IceAgeTrail_2019_BL_Aardvark.json
@@ -1,0 +1,45 @@
+{
+  "dct_title_s": "Ice Age Trail Wisconsin 2019",
+  "dct_description_sm": [
+    "This line data layer represents the Ice Age Trail for Wisconsin in 2019. The dataset was originally published by the Ice Age Trail Alliance on May 14, 2012 and later updated on September 25, 2019.[This vector line dataset represents the Ice Age National Scenic Trail and select other trails in the vicinity of the Ice Age Trail in Wisconsin.]"
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Ice Age Trail Alliance"
+  ],
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Line data"
+  ],
+  "dcat_theme_sm": [
+    "Society"
+  ],
+  "dct_temporal_sm": [
+    "2019-09-25"
+  ],
+  "dct_issued_s": "2012",
+  "gbl_indexYear_im": [
+    2019
+  ],
+  "dct_spatial_sm": [
+    "Wisconsin"
+  ],
+  "locn_geometry": "ENVELOPE(-87.340745, -92.662235, 45.699848, 42.643999)",
+  "dcat_bbox": "ENVELOPE(-92.662235, -87.340745, 45.699848, 42.643999)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>.[The Ice Age Trail Alliance (IATA) and National Park Service (NPS) shall not be held liable for improper or incorrect use of the data described and/or contained herein. These data and related graphics, if available, are not legal documents and are not intended to be used as such. These data are not of survey quality and not intended to be used for survey purposes. The information contained in these data is dynamic and may change over time. The data are not better than the original sources from which they were derived. It is the responsibility of the data user to use the data appropriately and consistent within the limitations of geospatial data in general and these data in particular. The related graphics are intended to aid the data user in acquiring relevant data; it is not appropriate to use the related graphics as data. The IATA and NPS give no warranty, expressed or implied, as to the accuracy, reliability, or completeness of these data. It is strongly recommended that these data be directly acquired from an IATA or NPS source and not indirectly through other sources, which may have changed the data in some way. Although these data have been processed successfully on a computer system at the IATA, no warranty expressed or implied is made regarding the utility of the data on another system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty. This disclaimer applies both to individual use of the data and aggregate use with other data.]",
+    "Although this data is being distributed by the American Geographical Society Library at the University of Wisconsin-Milwaukee Libraries, no warranty expressed or implied is made by the University as to the accuracy of the data and related materials. The act of distribution shall not constitute any such warranty, and no responsibility is assumed by the University in the use of this data, or related materials.<br/><br/>[Data should not be used beyond 1:24,000-scale.  Acknowledgement of the Ice Age Trail Alliance when using the data set as a source.]"
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Shapefile",
+  "gbl_wxsIdentifier_s": "druid:10172E23-72C2-4F45-AC7F-38E564C4E0F1",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.uwm.edu/10172E23-72C2-4F45-AC7F-38E564C4E0F1\",\"http://schema.org/downloadUrl\":\"http://stacks.uwm.edu/file/druid:10172E23-72C2-4F45-AC7F-38E564C4E0F1/data.zip\"}",
+  "id": "10172E23-72C2-4F45-AC7F-38E564C4E0F1",
+  "gbl_mdModified_dt": "2023-01-26T21:41:53.8461956Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/c233bA62500a_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/c233bA62500a_BL_Aardvark.json
@@ -1,0 +1,31 @@
+{
+    "dct_title_s": "Military map of Cuba 1:62,500 1913",
+    "dct_description_sm": ["This polygon data layer represents an Index Map for the<br/>                    Military map of Cuba 1913 series of maps held by the American Geographical<br/>                    Society Library."],
+    "dct_language_sm": ["eng"],
+    "dct_creator_sm": ["American Geographical Society Library - UWM Libraries (GIS Staff, University of Wisconsin-Milwaukee)"],
+    "schema_provider_s": "American Geographical Society Library - UWM Libraries",
+    "gbl_resourceClass_sm": ["Datasets"],
+    "gbl_resourceType_sm": ["Polygon data"],
+    "dcat_theme_sm": [
+        "Boundaries",
+        "Elevation",
+        "Military",
+        "Property",
+        "Transportation"
+    ],
+    "dct_temporal_sm": ["1913"],
+    "dct_issued_s": "2043",
+    "gbl_indexYear_im": [1913],
+    "dct_spatial_sm": ["Cuba"],
+    "locn_geometry": "ENVELOPE(-74, -85, 23.5, 19.5)",
+    "dcat_bbox": "ENVELOPE(-85, -74, 23.5, 19.5)",
+    "dct_rights_sm": ["Please see the UWM Libraries statement on Copyright and<br/>                            Digital Collections."],
+    "dct_accessRights_s": "Public",
+    "dct_format_s": "GeoJSON",
+    "gbl_wxsIdentifier_s": "druid:A66020BF-5600-4E9E-8815-3ABDE0C0B556",
+    "dct_references_s": "{\"https://openindexmaps.org\": \"https://raw.githubusercontent.com/OpenIndexMaps/edu.uwm/main/233bA62500a.geojson\"}",
+    "id": "A66020BF-5600-4E9E-8815-3ABDE0C0B556",
+    "gbl_mdModified_dt": "2023-02-14T20:07:59.6835138Z",
+    "gbl_mdVersion_s": "Aardvark",
+    "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/c233bA62500a_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/c233bA62500a_BL_Aardvark.json
@@ -22,9 +22,9 @@
     "dct_rights_sm": ["Please see the UWM Libraries statement on Copyright and<br/>                            Digital Collections."],
     "dct_accessRights_s": "Public",
     "dct_format_s": "GeoJSON",
-    "gbl_wxsIdentifier_s": "druid:A66020BF-5600-4E9E-8815-3ABDE0C0B556",
+    "gbl_wxsIdentifier_s": "druid:FDD35238-506A-4CB4-BF56-0592CC70F4D2",
     "dct_references_s": "{\"https://openindexmaps.org\": \"https://raw.githubusercontent.com/OpenIndexMaps/edu.uwm/main/233bA62500a.geojson\"}",
-    "id": "A66020BF-5600-4E9E-8815-3ABDE0C0B556",
+    "id": "FDD35238-506A-4CB4-BF56-0592CC70F4D2",
     "gbl_mdModified_dt": "2023-02-14T20:07:59.6835138Z",
     "gbl_mdVersion_s": "Aardvark",
     "gbl_suppressed_b": false

--- a/test/fixtures/files/uwm_documents/c300bA2000000_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/c300bA2000000_BL_Aardvark.json
@@ -1,0 +1,46 @@
+{
+  "dct_title_s": "Africa 1:2,000,000 1886-1902",
+  "dct_description_sm": [
+    "This polygon data layer represents an Index Map for the Afrique / publié par le Service Géographique de l'Armée / Africa 1886-1902 series of maps held by the American Geographical Society Library."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "American Geographical Society Library - UWM Libraries (GIS Staff, University of Wisconsin-Milwaukee)"
+  ],
+  "schema_provider_s": "American Geographical Society Library - UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Polygon data"
+  ],
+  "dcat_theme_sm": [
+    "Boundaries",
+    "Elevation",
+    "Military",
+    "Property"
+  ],
+  "dct_temporal_sm": [
+    "1902"
+  ],
+  "dct_issued_s": "1999",
+  "gbl_indexYear_im": [
+    1902
+  ],
+  "dct_spatial_sm": [
+    "Africa"
+  ],
+  "locn_geometry": "ENVELOPE(56.662771, -26.662771, 43.216667, -36)",
+  "dcat_bbox": "ENVELOPE(-26.662771, 56.662771, 43.216667, -36)",
+  "dct_rights_sm": [],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "GeoJSON",
+  "gbl_wxsIdentifier_s": "druid:792B5970-00BA-426F-90D3-AE9D370372D0",
+  "dct_references_s": "{\"https://openindexmaps.org\": \"https://raw.githubusercontent.com/OpenIndexMaps/edu.uwm/main/300bA2000000.geojson\"}",
+  "id": "792B5970-00BA-426F-90D3-AE9D370372D0",
+  "gbl_mdModified_dt": "2023-02-14T20:07:59.906442Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/c413_2bA100000_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/c413_2bA100000_BL_Aardvark.json
@@ -1,0 +1,46 @@
+{
+  "dct_title_s": "Survey of Israel 1:100,000 1999",
+  "dct_description_sm": [
+    "This polygon data layer represents an Index Map for the Survey of Israel 1:100,000 1999 series of maps held by the American Geographical Society Library. "
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "American Geographical Society Library - UWM Libraries (GIS Staff, University of Wisconsin-Milwaukee)"
+  ],
+  "schema_provider_s": "American Geographical Society Library - UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Polygon data"
+  ],
+  "dcat_theme_sm": [
+    "Boundaries",
+    "Elevation",
+    "Military",
+    "Property"
+  ],
+  "dct_temporal_sm": [
+    "1999"
+  ],
+  "dct_issued_s": "1999",
+  "gbl_indexYear_im": [
+    1999
+  ],
+  "dct_spatial_sm": [
+    "Israel"
+  ],
+  "locn_geometry": "ENVELOPE(35.96167, 34.05167, 33.38334, 29.32583)",
+  "dcat_bbox": "ENVELOPE(34.05167, 35.96167, 33.38334, 29.32583)",
+  "dct_rights_sm": [],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "GeoJSON",
+  "gbl_wxsIdentifier_s": "druid:624AFBF2-D54D-4DDB-A23E-F3F9FE9CD60D",
+  "dct_references_s": "{\"https://openindexmaps.org\": \"https://raw.githubusercontent.com/OpenIndexMaps/edu.uwm/main/413_2bA100000.geojson\"}",
+  "id": "624AFBF2-D54D-4DDB-A23E-F3F9FE9CD60D",
+  "gbl_mdModified_dt": "2023-02-14T20:08:00.0152167Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}

--- a/test/fixtures/files/uwm_documents/c460cbA250000_BL_Aardvark.json
+++ b/test/fixtures/files/uwm_documents/c460cbA250000_BL_Aardvark.json
@@ -1,0 +1,52 @@
+{
+  "dct_title_s": "Northwest China 1:250,000 1943",
+  "dct_description_sm": [
+    "This polygon data layer represents an Index Map for the Gansu Sheng, China 1943 series of maps held by the American Geographical Society Library. "
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "American Geographical Society Library - UWM Libraries (GIS Staff, University of Wisconsin-Milwaukee)"
+  ],
+  "schema_provider_s": "American Geographical Society Library - UWM Libraries",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Polygon data"
+  ],
+  "dcat_theme_sm": [
+    "Boundaries",
+    "Elevation",
+    "Military",
+    "Property",
+    "Transportation"
+  ],
+  "dct_temporal_sm": [
+    "1943"
+  ],
+  "dct_issued_s": "2043",
+  "gbl_indexYear_im": [
+    1943
+  ],
+  "dct_spatial_sm": [
+    "Xinjiang",
+    "Gansu",
+    "Qinghai",
+    "China"
+  ],
+  "locn_geometry": "ENVELOPE(104, 74, 44, 34)",
+  "dcat_bbox": "ENVELOPE(74, 104, 44, 34)",
+  "dct_rights_sm": [
+    "<a href=\"https://uwm.edu/libraries/digital-collections/copyright-digcoll/\">Please see the UWM Libraries statement on Copyright and Digital Collections</a>."
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "GeoJSON",
+  "gbl_wxsIdentifier_s": "druid:A66020BF-5600-4E9E-8815-3ABDE0C0B556",
+  "dct_references_s": "{\"https://openindexmaps.org\": \"https://raw.githubusercontent.com/OpenIndexMaps/edu.uwm/main/460cbA250000.geojson\"}",
+  "id": "A66020BF-5600-4E9E-8815-3ABDE0C0B556",
+  "gbl_mdModified_dt": "2023-02-14T20:08:00.122908Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "gbl_suppressed_b": false
+}


### PR DESCRIPTION
This PR adds the UWM test fixtures from Google Drive. It expands the json schema validation step in our GH CI actions to sanity check GBL and UWM fixtures. It also includes a little helper to render the HTML present in the Rights field values.

Fixes #7 