### PR TITLE
Exclude bootstrap from dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,6 @@ updates:
   - package-ecosystem: 'bundler'
     directory: '/'
     schedule:
-      interval: 'daily'   
+      interval: 'daily'
+    ignore:
+      - dependency-name: "bootstrap"


### PR DESCRIPTION
We do not want to upgrade to Bootstrap 5.x until at least the next major Blacklight release.