### PR TITLE
Bug fix: homepage map on mobile

### DIFF
--- a/app/assets/stylesheets/modules/_homepage.scss
+++ b/app/assets/stylesheets/modules/_homepage.scss
@@ -19,3 +19,7 @@
 #main-container [data-map="home"] .leaflet-control-container .search-control a:hover {
   //color: $white;
 }
+
+#wrapper-map {
+  min-height:400px;
+}


### PR DESCRIPTION
The map's wrapping div needs a minimum height to render on the page.

Fixes #8

### Before
<img width="647" alt="Screenshot 2023-03-10 at 2 31 20 PM" src="https://user-images.githubusercontent.com/69827/224422875-b807c3b8-4513-46af-a7aa-c15961acc434.png">


### After
<img width="647" alt="Screenshot 2023-03-10 at 2 30 54 PM" src="https://user-images.githubusercontent.com/69827/224422908-7b7937f4-be12-4345-841c-35db2182fce1.png">
