### PR TITLE
Bug fix: roll sprockets back to v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ gem "blacklight_advanced_search", git: "https://github.com/ewlarson/blacklight_a
 gem "geoblacklight", "~> 4.0"
 gem "geoblacklight_sidecar_images", "~> 1.0"
 gem "mini_magick", "~> 4.0"
-gem "sprockets", "< 5.0"
+gem "sprockets", "< 4.0"
 
 group :development, :test do
   gem "solr_wrapper", ">= 0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,9 +452,9 @@ GEM
       minitar
       retriable
       ruby-progressbar
-    sprockets (4.2.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
+      rack (> 1, < 3)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -559,7 +559,7 @@ DEPENDENCIES
   simplecov
   sitemap_generator (~> 6.3)
   solr_wrapper (>= 0.3)
-  sprockets (< 5.0)
+  sprockets (< 4.0)
   sprockets-rails
   sqlite3 (~> 1.4)
   standardrb

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,3 @@
-//= link application.css
-//= link application.js
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,4 +3,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
-//= link_tree ../../../vendor/javascript .js


### PR DESCRIPTION
Sprockets v4 includes a strange asset precompile and/or caching race condition that fails to deploy correctly or test via CI successfully. We're using sprockets v3 in the BTAA Geoportal, so let's stay at v3 for now.

Reverting to sprockets v3 to fix the build.