### PR TITLE
Show the download button regardless of restriction

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -35,4 +35,9 @@ class SolrDocument
 
     sidecar
   end
+
+  # Show the download button regardless of restriction
+  def public?
+    true
+  end
 end


### PR DESCRIPTION
This overrides the document.public? variable in solr_document.rb in order to show the download button on restricted datasets.

This is not a permanent solution.

BTAA has a really elegant solution, for example: https://geo.btaa.org/catalog/999-0003-010

They use a local field: b1g_access_s