### PR TITLE
Bugfix/generated downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,6 @@ pickle-email-*.html
 !/log/.keep
 !/tmp/.keep
 
-# Ignore Cached Downloads
-/cached_downloads/*
-!/cached_downloads/.keep
-
-
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/master.key

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ pickle-email-*.html
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+!/tmp/cache/.keep
+!/tmp/cache/downloads/.keep
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ pickle-email-*.html
 !/log/.keep
 !/tmp/.keep
 
+# Ignore Cached Downloads
+/cached_downloads/*
+!/cached_downloads/.keep
+
+
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/master.key

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,6 @@ pickle-email-*.html
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-!/tmp/cache/.keep
-!/tmp/cache/downloads/.keep
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ CARTO_ONECLICK_LINK: 'http://oneclick.carto.com/'
 ARCGIS_BASE_URL: 'https://www.arcgis.com/home/webmap/viewer.html'
 
 # Download path can be configured using this setting
-#DOWNLOAD_PATH: "./tmp/cache/downloads"
+DOWNLOAD_PATH: "./tmp/cache/downloads"
 
 # The bq boost value for spatial search matches within a bounding box
 BBOX_WITHIN_BOOST: '10'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ CARTO_ONECLICK_LINK: 'http://oneclick.carto.com/'
 ARCGIS_BASE_URL: 'https://www.arcgis.com/home/webmap/viewer.html'
 
 # Download path can be configured using this setting
-# DOWNLOAD_PATH: "./tmp/cache/downloads" (This is the default so this should be okay to comment out)
+#DOWNLOAD_PATH: "./tmp/cache/downloads"
 
 # The bq boost value for spatial search matches within a bounding box
 BBOX_WITHIN_BOOST: '10'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ CARTO_ONECLICK_LINK: 'http://oneclick.carto.com/'
 ARCGIS_BASE_URL: 'https://www.arcgis.com/home/webmap/viewer.html'
 
 # Download path can be configured using this setting
-DOWNLOAD_PATH: "./cached_downloads"
+# DOWNLOAD_PATH: "./tmp/cache/downloads" (This is the default so this should be okay to comment out)
 
 # The bq boost value for spatial search matches within a bounding box
 BBOX_WITHIN_BOOST: '10'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ CARTO_ONECLICK_LINK: 'http://oneclick.carto.com/'
 ARCGIS_BASE_URL: 'https://www.arcgis.com/home/webmap/viewer.html'
 
 # Download path can be configured using this setting
-DOWNLOAD_PATH: "./tmp/cache/downloads"
+DOWNLOAD_PATH: "./cached_downloads"
 
 # The bq boost value for spatial search matches within a bounding box
 BBOX_WITHIN_BOOST: '10'


### PR DESCRIPTION
Forces downloads into a new folder to avoid needing to create the tmp/cached/downloads folder on each deploy.