### PR TITLE
Experiment with non-latin title sorting

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -14,6 +14,7 @@
 - Local development depends on Ruby and Java. Solr is required for normal application behavior.
 - Prefer the documented local startup task: `bundle exec rake uwm:server`.
 - After modifying any Ruby file or Ruby-based config, run `bundle exec standardrb --fix`.
+- Before wrapping up a task that changed Ruby code, verify whether `bundle exec standardrb --fix` is needed and run it if formatting or style drift is possible.
 - After modifying application code, tests, database code, routes, initializers, or environment/configuration that could affect runtime behavior, run `RAILS_ENV=test bundle exec rake ci`.
 - For documentation-only or clearly isolated non-runtime changes, skip the full test suite unless I explicitly ask you to test the app.
 - If full verification is too expensive during iteration, run the narrowest relevant check first, then run broader verification before finishing when the change affects runtime behavior.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Working agreements
 
+- Do not edit files until I explicitly approve the change, even if the likely fix seems obvious. Prefer diagnosis first, then propose the exact edit.
 - Whenever reasonable, reference available documentation:
   - AGSL GeoDiscovery Documentation site: https://uwm-libraries.github.io/GeoDiscovery-Documentation/
   - GeoBlacklight Documentation Site for 4.x: https://geoblacklight.org/4.x/docs/
@@ -20,7 +21,11 @@
 - Do not edit vendored, generated, or environment-specific files unless the task clearly requires it.
 - Before changing deployment-related code or configuration, review the existing deployment setup and call out any operational risk.
 - If a required verification step cannot run, say so clearly and explain why.
-- If it's possible that errors are related to the production environment, consider that a possiblity and ask for follow up information from the server (e.g. logs, versions, locations, permissions, etc.)
+- When I say “local,” I usually mean Ubuntu via WSL on a work machine. Sometimes I may be working on macOS, but usually local work means WSL Ubuntu. This is where I use `RAILS_ENV=development` and `RAILS_ENV=test`.
+- The Development and Production servers both run on RHEL 8 and both use `RAILS_ENV=production`. Do not assume the Development server behaves like a local Rails development environment.
+- If an error may be environment-specific, ask for follow-up information from the relevant server before proposing code changes (e.g. logs, versions, locations, permissions, and environment variables).
+- On server-like environments for this project, confirm the actual `RAILS_ENV` in use before troubleshooting. Some hosts that function as “development” infrastructure may still run with `RAILS_ENV=production`.
+- For sitemap issues, remember this app serves the sitemap from generated static files in `public/`, not from a Rails route. Check for `public/sitemap.xml.gz` and the Whenever schedule before proposing route changes.
 
 ## Repository-specific preferences
 
@@ -40,8 +45,8 @@
 - Do not remove or simplify AGSL-specific behavior merely because upstream GeoBlacklight handles the same area differently; first confirm the local reason for the customization.
 - When unsure why a customization exists, inspect git history and nearby code before replacing it with a cleaner-looking upstream-style implementation.
 - Prefer small, reviewable changes that preserve current behavior unless the task explicitly asks for refactoring.
+- Flag any change that may impact WCAG compliance or web accessibility.
 - For view-layer changes, check for existing partials, helpers, and Stimulus/JavaScript hooks before restructuring templates.
 - For indexing or metadata normalization changes, document sample input and expected Solr output in notes or the final summary when possible.
 - When adding configuration, prefer patterns already used in the repository so deployment and local setup remain predictable.
 - Flag any change that may require reindexing, cache clearing, restart, or redeploy.
-- Flag any change that may impact WCAG compliance or web accessibility

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -15,6 +15,7 @@
 - Local development depends on Ruby and Java. Solr is required for normal application behavior.
 - Prefer the documented local startup task: `bundle exec rake uwm:server`.
 - After modifying any Ruby file or Ruby-based config, run `bundle exec standardrb --fix`.
+- Before wrapping up a task that changed Ruby code, verify whether `bundle exec standardrb --fix` is needed and run it if formatting or style drift is possible.
 - After modifying application code, tests, database code, routes, initializers, or environment/configuration that could affect runtime behavior, run `RAILS_ENV=test bundle exec rake ci`.
 - For documentation-only or clearly isolated non-runtime changes, skip the full test suite unless I explicitly ask you to test the app.
 - If full verification is too expensive during iteration, run the narrowest relevant check first, then run broader verification before finishing when the change affects runtime behavior.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -323,11 +323,11 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field "score desc, dct_title_sort asc", label: "Relevance"
-    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} desc, dct_title_sort asc", label: "Year (Newest first)"
-    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} asc, dct_title_sort asc", label: "Year (Oldest first)"
-    config.add_sort_field "dct_title_sort asc", label: "Title (A-Z)"
-    config.add_sort_field "dct_title_sort desc", label: "Title (Z-A)"
+    config.add_sort_field "score desc, #{Settings.FIELDS.TITLE_SORT} asc", label: "Relevance"
+    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} desc, #{Settings.FIELDS.TITLE_SORT} asc", label: "Year (Newest first)"
+    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} asc, #{Settings.FIELDS.TITLE_SORT} asc", label: "Year (Oldest first)"
+    config.add_sort_field "#{Settings.FIELDS.TITLE_SORT} asc", label: "Title (A-Z)"
+    config.add_sort_field "#{Settings.FIELDS.TITLE_SORT} desc", label: "Title (Z-A)"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -4,7 +4,7 @@ development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8985/solr/blacklight-core" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,6 +87,7 @@ FIELDS:
   :SUPPRESSED: 'gbl_suppressed_b'
   :TEMPORAL_COVERAGE: 'dct_temporal_sm'
   :TITLE: 'dct_title_s'
+  :TITLE_SORT: 'dct_title_latin_first_sort'
   :VERSION: 'dct_isVersionOf_sm'
   :WXS_IDENTIFIER: 'gbl_wxsIdentifier_s'
 

--- a/lib/tasks/uwm.rake
+++ b/lib/tasks/uwm.rake
@@ -6,12 +6,13 @@ desc "Run test suite"
 task :ci do
   shared_solr_opts = {managed: true, verbose: true, persist: false, download_dir: "tmp"}
   shared_solr_opts[:version] = ENV["SOLR_VERSION"] if ENV["SOLR_VERSION"]
+  test_solr_url = "http://127.0.0.1:8985/solr/blacklight-core"
 
   success = true
   SolrWrapper.wrap(shared_solr_opts.merge(port: 8985, instance_dir: "tmp/blacklight-core")) do |solr|
     solr.with_collection(name: "blacklight-core", dir: Rails.root.join("solr", "conf").to_s) do
-      system "RAILS_ENV=test bundle exec rake uwm:index:seed"
-      success = system 'RUBYOPT=W0 RAILS_ENV=test TESTOPTS="-v" bundle exec rails test:system test'
+      system "SOLR_URL=#{test_solr_url} RAILS_ENV=test bundle exec rake uwm:index:seed"
+      success = system "SOLR_URL=#{test_solr_url} RUBYOPT=W0 RAILS_ENV=test TESTOPTS=\"-v\" bundle exec rails test:system test"
     end
   end
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -5,6 +5,7 @@
     <field name="_version_" type="long"   stored="true" indexed="true"/>
     <field name="timestamp" type="date"   stored="true" indexed="true" default="NOW"/>
     <field name="id"        type="string" stored="true" indexed="true" required="true"/>
+    <field name="dct_title_latin_first_sort" type="text_latin_first_sort" stored="false" indexed="true"/>
 
     <!-- core generated fields -->
     <field name="text" type="text_en" stored="false" indexed="true" multiValued="true"
@@ -117,6 +118,18 @@
       </analyzer>
     </fieldType>
 
+    <fieldType name="text_latin_first_sort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.TrimFilterFactory" />
+        <filter class="solr.ASCIIFoldingFilterFactory" />
+        <filter class="solr.PatternReplaceFilterFactory" pattern="^[^\p{L}\p{Nd}]+" replacement="" replace="first"/>
+        <filter class="solr.PatternReplaceFilterFactory" pattern="^([^a-z0-9].*)$" replacement="zzzz $1" replace="first"/>
+        <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z0-9 ])" replacement="" replace="all"/>
+      </analyzer>
+    </fieldType>
+
     <!-- for spell checking -->
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
       <analyzer>
@@ -176,6 +189,7 @@
   <!-- for sorting text fields -->
   <copyField source="schema_provider_s"   dest="schema_provider_sort"/>
   <copyField source="dct_title_s"         dest="dct_title_sort"/>
+  <copyField source="dct_title_s"         dest="dct_title_latin_first_sort"/>
 
   <!-- for spell checking -->
   <copyField source="dct_title_s" dest="spell"/>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -113,7 +113,7 @@
       <int name="ps">0</int>
       <float name="tie">0.01</float>
       <str name="fl">*,score</str>
-      <str name="sort">score desc, dct_title_sort asc</str>
+      <str name="sort">score desc, dct_title_latin_first_sort asc</str>
       <str name="q.alt">*:*</str>
       <str name="qf">
         text^1

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -1,10 +1,54 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "json"
 
 class CatalogControllerTest < ActionDispatch::IntegrationTest
+  SORT_TEST_TAG = "sort-script-test".freeze
+
+  setup do
+    @sort_test_ids = %w[sort-test-latin sort-test-chinese]
+    Blacklight.default_index.connection.add(
+      [
+        build_sort_test_doc("sort-test-latin", "Alpha sort script test"),
+        build_sort_test_doc("sort-test-chinese", "北京市城区街道图")
+      ]
+    )
+    Blacklight.default_index.connection.commit
+  end
+
+  teardown do
+    Blacklight.default_index.connection.delete_by_query("id:(#{@sort_test_ids.join(' ')})")
+    Blacklight.default_index.connection.commit
+  end
+
   test "should return admin view" do
     get "/catalog/mit-001145244/admin"
     assert_response :success
+  end
+
+  test "title sort deprioritizes non latin script titles" do
+    get "/", params: { q: SORT_TEST_TAG, search_field: "all_fields", sort: "#{Settings.FIELDS.TITLE_SORT} asc" }
+
+    assert_response :success
+    assert_includes response.body, "Alpha sort script test"
+    assert_includes response.body, "北京市城区街道图"
+    assert_operator response.body.index("Alpha sort script test"), :<, response.body.index("北京市城区街道图")
+  end
+
+  private
+
+  def build_sort_test_doc(id, title)
+    fixture_doc.merge(
+      "id" => id,
+      "dct_title_s" => title,
+      "dct_description_sm" => [SORT_TEST_TAG]
+    )
+  end
+
+  def fixture_doc
+    @fixture_doc ||= JSON.parse(
+      Rails.root.join("test/fixtures/files/gbl_documents/index-map-stanford.json").read
+    )
   end
 end

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 require "json"
 
 class CatalogControllerTest < ActionDispatch::IntegrationTest
-  SORT_TEST_TAG = "sort-script-test".freeze
+  SORT_TEST_TAG = "sort-script-test"
 
   setup do
     @sort_test_ids = %w[sort-test-latin sort-test-chinese]
@@ -18,7 +18,7 @@ class CatalogControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    Blacklight.default_index.connection.delete_by_query("id:(#{@sort_test_ids.join(' ')})")
+    Blacklight.default_index.connection.delete_by_query("id:(#{@sort_test_ids.join(" ")})")
     Blacklight.default_index.connection.commit
   end
 
@@ -28,7 +28,7 @@ class CatalogControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "title sort deprioritizes non latin script titles" do
-    get "/", params: { q: SORT_TEST_TAG, search_field: "all_fields", sort: "#{Settings.FIELDS.TITLE_SORT} asc" }
+    get "/", params: {q: SORT_TEST_TAG, search_field: "all_fields", sort: "#{Settings.FIELDS.TITLE_SORT} asc"}
 
     assert_response :success
     assert_includes response.body, "Alpha sort script test"


### PR DESCRIPTION
Adjusted default title sorting so records with non-Latin-leading titles are deprioritized in alphabetical order, while keeping the existing sort options and relevance/year tie-break behavior intact. This adds a dedicated Solr sort field and analyzer for “Latin-first” title sorting, updates Blacklight to use that field, and adds a controller regression test covering English-vs-Chinese title ordering.

The branch also fixes test Solr configuration so local/CI test runs consistently use the isolated test core on 8985 instead of accidentally falling back to the dev Solr port. bundle exec rake ci now passes with the updated configuration.