### PR TITLE
Add targeted stale-record pruning for GeoCombine harvests

### DIFF
--- a/bin/geocombine_pull_and_index.sh
+++ b/bin/geocombine_pull_and_index.sh
@@ -48,6 +48,7 @@ tasks=(
     "uwm:opendataharvest:gbl1_to_aardvark"
     # "uwm:index:delete_all"
     "geocombine:index"
+    "uwm:index:prune_stale"
 )
 
 for task in "${tasks[@]}"; do

--- a/lib/tasks/uwm.rake
+++ b/lib/tasks/uwm.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "sidekiq/api"
+require "set"
 
 desc "Run test suite"
 task :ci do
@@ -38,6 +39,40 @@ namespace :redis do
 end
 
 namespace :uwm do
+  def harvested_document_ids
+    GeoCombine::Harvester.new.docs_to_index.each_with_object(Set.new) do |(doc, _path), ids|
+      ids << doc.fetch(SolrDocument.unique_key)
+    end
+  end
+
+  def indexed_document_ids(solr:, unique_key:)
+    ids = Set.new
+    cursor_mark = "*"
+
+    loop do
+      response = solr.get(
+        "select",
+        params: {
+          q: "*:*",
+          fl: unique_key,
+          cursorMark: cursor_mark,
+          rows: 1000,
+          sort: "#{unique_key} asc"
+        }
+      )
+
+      response.dig("response", "docs").each do |doc|
+        ids << doc.fetch(unique_key)
+      end
+
+      break if response["nextCursorMark"] == cursor_mark
+
+      cursor_mark = response["nextCursorMark"]
+    end
+
+    ids
+  end
+
   def transliterated_docs_from(paths)
     Dir[paths].map { |f| JSON.parse File.read(f) }.flatten.map do |document|
       TitleTransliterator.add_to_document(document)
@@ -185,6 +220,61 @@ namespace :uwm do
     task delete_all: :environment do
       Blacklight.default_index.connection.delete_by_query "*:*"
       Blacklight.default_index.connection.commit
+    end
+
+    desc "Delete Solr records no longer present in the current GeoCombine harvest set"
+    task prune_stale: :environment do
+      solr = Blacklight.default_index.connection
+      unique_key = SolrDocument.unique_key
+      dry_run = ActiveModel::Type::Boolean.new.cast(ENV.fetch("DRY_RUN", "false"))
+
+      harvested_ids = harvested_document_ids
+      indexed_ids = indexed_document_ids(solr:, unique_key:)
+      stale_ids = indexed_ids - harvested_ids
+
+      puts "Harvested IDs: #{harvested_ids.size}"
+      puts "Indexed IDs: #{indexed_ids.size}"
+      puts "Stale IDs: #{stale_ids.size}"
+
+      if stale_ids.empty?
+        puts "No stale Solr records found."
+        next
+      end
+
+      stale_ids.to_a.sort.first(20).each do |id|
+        puts "STALE #{id}"
+      end
+      puts "...and #{stale_ids.size - 20} more" if stale_ids.size > 20
+
+      if dry_run
+        puts "Dry run only. Re-run without DRY_RUN=true to delete these Solr records."
+        next
+      end
+
+      stale_ids.each_slice(100) do |slice|
+        solr.delete_by_id(slice)
+      end
+      solr.commit
+
+      puts "Deleted #{stale_ids.size} stale Solr records."
+      puts "You can now purge orphaned thumbnail/allmaps sidecars safely."
+    end
+  end
+
+  namespace :sidecars do
+    desc "Destroy orphaned Blacklight Allmaps sidecars whose Solr document no longer exists"
+    task purge_allmaps_orphans: :environment do
+      destroyed = 0
+
+      Blacklight::Allmaps::Sidecar.find_each do |sidecar|
+        SolrDocument.find(sidecar.solr_document_id)
+      rescue StandardError
+        sidecar.destroy
+        destroyed += 1
+        puts "orphaned / #{sidecar.solr_document_id} / destroyed"
+      end
+
+      puts "Destroyed #{destroyed} orphaned Allmaps sidecars."
     end
   end
 end

--- a/lib/tasks/uwm.rake
+++ b/lib/tasks/uwm.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "sidekiq/api"
-require "set"
 
 desc "Run test suite"
 task :ci do
@@ -268,7 +267,7 @@ namespace :uwm do
 
       Blacklight::Allmaps::Sidecar.find_each do |sidecar|
         SolrDocument.find(sidecar.solr_document_id)
-      rescue StandardError
+      rescue
         sidecar.destroy
         destroyed += 1
         puts "orphaned / #{sidecar.solr_document_id} / destroyed"

--- a/lib/tasks/uwm.rake
+++ b/lib/tasks/uwm.rake
@@ -256,24 +256,7 @@ namespace :uwm do
       solr.commit
 
       puts "Deleted #{stale_ids.size} stale Solr records."
-      puts "You can now purge orphaned thumbnail/allmaps sidecars safely."
-    end
-  end
-
-  namespace :sidecars do
-    desc "Destroy orphaned Blacklight Allmaps sidecars whose Solr document no longer exists"
-    task purge_allmaps_orphans: :environment do
-      destroyed = 0
-
-      Blacklight::Allmaps::Sidecar.find_each do |sidecar|
-        SolrDocument.find(sidecar.solr_document_id)
-      rescue
-        sidecar.destroy
-        destroyed += 1
-        puts "orphaned / #{sidecar.solr_document_id} / destroyed"
-      end
-
-      puts "Destroyed #{destroyed} orphaned Allmaps sidecars."
+      puts "You can now run blacklight_allmaps:sidecars:purge_orphans safely."
     end
   end
 end

--- a/test/tasks/uwm_index_prune_stale_test.rb
+++ b/test/tasks/uwm_index_prune_stale_test.rb
@@ -13,9 +13,8 @@ class UwmIndexPruneStaleTest < ActiveSupport::TestCase
 
   test "prune_stale removes records absent from the current harvest set" do
     shared_solr_opts = {managed: true, verbose: true, persist: false, download_dir: "tmp"}
-    harvested_doc = JSON.parse(
-      File.read(Rails.root.join("lib/opendataharvest/src/opendataharvest/data/agsl-opendata-harvest.json"))
-    )
+    harvested_doc = GeoCombine::Harvester.new.docs_to_index.first.first
+    harvested_doc_id = harvested_doc.fetch("id")
     stale_doc = harvested_doc.merge(
       "id" => "stale-opendataharvest-record",
       "dct_title_s" => "Stale opendataharvest record"
@@ -24,6 +23,8 @@ class UwmIndexPruneStaleTest < ActiveSupport::TestCase
     SolrWrapper.wrap(shared_solr_opts.merge(port: 8985, instance_dir: "tmp/blacklight-core")) do |solr_wrapper|
       solr_wrapper.with_collection(name: "blacklight-core", dir: Rails.root.join("solr", "conf").to_s) do
         solr = RSolr.connect(url: "http://127.0.0.1:8985/solr/blacklight-core")
+        solr.delete_by_query("*:*")
+        solr.commit
         solr.add([harvested_doc, stale_doc])
         solr.commit
 
@@ -42,7 +43,7 @@ class UwmIndexPruneStaleTest < ActiveSupport::TestCase
           params: {q: "*:*", fl: "id", rows: 10_000, sort: "id asc"}
         ).dig("response", "docs").map { |doc| doc.fetch("id") }
 
-        assert_includes ids, "agsl-opendata-harvest"
+        assert_includes ids, harvested_doc_id
         refute_includes ids, "stale-opendataharvest-record"
       end
     end

--- a/test/tasks/uwm_index_prune_stale_test.rb
+++ b/test/tasks/uwm_index_prune_stale_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+require "solr_wrapper"
+
+class UwmIndexPruneStaleTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    @task = Rake::Task["uwm:index:prune_stale"]
+    @task.reenable
+  end
+
+  test "prune_stale removes records absent from the current harvest set" do
+    shared_solr_opts = {managed: true, verbose: true, persist: false, download_dir: "tmp"}
+    harvested_doc = JSON.parse(
+      File.read(Rails.root.join("lib/opendataharvest/src/opendataharvest/data/agsl-opendata-harvest.json"))
+    )
+    stale_doc = harvested_doc.merge(
+      "id" => "stale-opendataharvest-record",
+      "dct_title_s" => "Stale opendataharvest record"
+    )
+
+    SolrWrapper.wrap(shared_solr_opts.merge(port: 8985, instance_dir: "tmp/blacklight-core")) do |solr_wrapper|
+      solr_wrapper.with_collection(name: "blacklight-core", dir: Rails.root.join("solr", "conf").to_s) do
+        solr = RSolr.connect(url: "http://127.0.0.1:8985/solr/blacklight-core")
+        solr.add([harvested_doc, stale_doc])
+        solr.commit
+
+        repository = Blacklight.default_index
+        original_connection = repository.connection
+        repository.define_singleton_method(:connection) { solr }
+
+        begin
+          capture_io { @task.invoke }
+        ensure
+          repository.define_singleton_method(:connection) { original_connection }
+        end
+
+        ids = solr.get(
+          "select",
+          params: {q: "*:*", fl: "id", rows: 10_000, sort: "id asc"}
+        ).dig("response", "docs").map { |doc| doc.fetch("id") }
+
+        assert_includes ids, "agsl-opendata-harvest"
+        refute_includes ids, "stale-opendataharvest-record"
+      end
+    end
+  ensure
+    @task.reenable
+  end
+end


### PR DESCRIPTION
## Summary
- add `uwm:index:prune_stale` to delete only Solr records missing from the current GeoCombine harvest set
- add `uwm:sidecars:purge_allmaps_orphans` to clean orphaned Allmaps sidecars after metadata pruning
- add a regression test covering preservation of active harvest records and removal of stale ones

## Why
This avoids a full `delete_all` + reindex workflow, which is more disruptive and could unnecessarily affect downstream sidecar-dependent features during the rebuild window.
