### PR TITLE
Update GeoCombine and fix full CI coverage reporting

### DIFF
--- a/.example.env.development
+++ b/.example.env.development
@@ -2,10 +2,11 @@
 SOLR_PORT=8983
 SOLR_URL=http://127.0.0.1:8983/solr/blacklight-core
 SOLR_VERSION=9.1.1
-OGM_PATH=tmp/opengeometadata
 
 # GeoCombine
+OGM_PATH=tmp/opengeometadata
 SCHEMA_VERSION=Aardvark
+OGM_SKIP_RESTRICTED=false
 
 # Redis
 REDIS_URL=redis://localhost:6379/1

--- a/.example.env.production
+++ b/.example.env.production
@@ -10,8 +10,9 @@ GEOBLACKLIGHT_DB_USER=root
 GEOBLACKLIGHT_DB_PASSWORD=root
 
 # GeoCombine
-SCHEMA_VERSION=Aardvark
 OGM_PATH=/var/www/rubyapps/uwm-geoblacklight/shared/tmp/opengeometadata
+SCHEMA_VERSION=Aardvark
+OGM_SKIP_RESTRICTED=false
 
 # Redis
 REDIS_URL=redis://localhost:6379/1

--- a/.example.env.test
+++ b/.example.env.test
@@ -3,8 +3,7 @@ SOLR_PORT=8985
 SOLR_URL=http://127.0.0.1:8985/solr/blacklight-core
 SOLR_VERSION=9.1.1
 
-# OpenGeoMetadata
-OGM_PATH=tmp/opengeometadata
-
 # GeoCombine
+OGM_PATH=tmp/opengeometadata
 SCHEMA_VERSION=Aardvark
+OGM_SKIP_RESTRICTED=false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
-    geo_combine (0.9.2)
+    geo_combine (0.11.0)
       activesupport
       faraday-net_http_persistent (~> 2.0)
       faraday-retry (~> 2.2)
@@ -247,7 +247,7 @@ GEM
       mini_magick (~> 4.9.4)
       rails (>= 5.2, < 8.2)
       statesman (>= 3.4)
-    git (5.0.2)
+    git (5.0.4)
       activesupport (>= 5.0)
       addressable (~> 2.8)
       process_executer (~> 4.0)

--- a/lib/tasks/geocombine.rake
+++ b/lib/tasks/geocombine.rake
@@ -5,7 +5,9 @@ Rake::Task["geocombine:index"].clear if Rake::Task.task_defined?("geocombine:ind
 namespace :geocombine do
   desc "Index all JSON documents except Layers.json with the Rails environment loaded"
   task index: :environment do
-    harvester = GeoCombine::Harvester.new
+    harvester = GeoCombine::Harvester.new(
+      ogm_path: ENV.fetch("OGM_PATH", "tmp/opengeometadata")
+    )
     indexer = GeoCombine::Indexer.new
     indexer.index(harvester.docs_to_index)
   end

--- a/lib/tasks/uwm.rake
+++ b/lib/tasks/uwm.rake
@@ -18,8 +18,13 @@ task :ci do
           exception: false
         )
         success &&= system(
-          {"SOLR_URL" => managed_solr_url},
-          'env RUBYOPT=W0 RAILS_ENV=test TESTOPTS="-v" bundle exec rails test:system test',
+          {"SIMPLECOV_COMMAND_NAME" => "Unit Tests", "SOLR_URL" => managed_solr_url},
+          'env RUBYOPT=W0 RAILS_ENV=test TESTOPTS="-v" bundle exec rails test',
+          exception: false
+        )
+        success &&= system(
+          {"SIMPLECOV_COMMAND_NAME" => "System Tests", "SOLR_URL" => managed_solr_url},
+          'env RUBYOPT=W0 RAILS_ENV=test TESTOPTS="-v" bundle exec rails test:system',
           exception: false
         )
       end
@@ -56,7 +61,11 @@ namespace :uwm do
   end
 
   def harvested_document_ids
-    GeoCombine::Harvester.new.docs_to_index.each_with_object(Set.new) do |(doc, _path), ids|
+    harvester = GeoCombine::Harvester.new(
+      ogm_path: ENV.fetch("OGM_PATH", "tmp/opengeometadata")
+    )
+
+    harvester.docs_to_index.each_with_object(Set.new) do |(doc, _path), ids|
       ids << doc.fetch(SolrDocument.unique_key)
     end
   end

--- a/test/services/restricted_display_note_test.rb
+++ b/test/services/restricted_display_note_test.rb
@@ -49,7 +49,11 @@ class RestrictedDisplayNoteTest < ActiveSupport::TestCase
         JSON.generate(gbl_fixture_document("actual-raster1.json"))
       )
 
-      harvester = GeoCombine::Harvester.new(ogm_path: dir, schema_version: "Aardvark")
+      harvester = GeoCombine::Harvester.new(
+        ogm_path: dir,
+        schema_version: "Aardvark",
+        skip_restricted: false
+      )
       document, = harvester.docs_to_index.first
 
       assert_includes document["gbl_displayNote_sm"], RestrictedDisplayNote::NOTE
@@ -64,7 +68,11 @@ class RestrictedDisplayNoteTest < ActiveSupport::TestCase
         JSON.generate(gbl_fixture_document("actual-raster1.json"))
       )
 
-      harvester = GeoCombine::Harvester.new(ogm_path: dir, schema_version: "Aardvark")
+      harvester = GeoCombine::Harvester.new(
+        ogm_path: dir,
+        schema_version: "Aardvark",
+        skip_restricted: false
+      )
       document, = harvester.docs_to_index.first
 
       assert_nil document["gbl_displayNote_sm"]

--- a/test/tasks/uwm_index_prune_stale_test.rb
+++ b/test/tasks/uwm_index_prune_stale_test.rb
@@ -12,7 +12,9 @@ class UwmIndexPruneStaleTest < ActiveSupport::TestCase
   end
 
   test "prune_stale removes records absent from the current harvest set" do
-    harvested_doc = GeoCombine::Harvester.new.docs_to_index.first.first
+    harvested_doc = GeoCombine::Harvester.new(
+      ogm_path: ENV.fetch("OGM_PATH", "tmp/opengeometadata")
+    ).docs_to_index.first.first
     harvested_doc_id = harvested_doc.fetch("id")
     stale_doc = harvested_doc.merge(
       "id" => "stale-opendataharvest-record",
@@ -24,7 +26,9 @@ class UwmIndexPruneStaleTest < ActiveSupport::TestCase
         "select",
         params: {q: "*:*", rows: 10_000, sort: "id asc"}
       ).dig("response", "docs").map do |doc|
-        doc.except("_version_", "score")
+        doc.except("_version_", "score").reject do |field, _value|
+          field.start_with?("solr_bboxtype__")
+        end
       end
 
       begin
@@ -63,23 +67,12 @@ class UwmIndexPruneStaleTest < ActiveSupport::TestCase
   private
 
   def with_test_solr
-    if ENV["SOLR_URL"]
-      existing_solr = RSolr.connect(url: ENV.fetch("SOLR_URL"))
-      begin
-        existing_solr.get("admin/ping")
-        yield existing_solr
-        return
-      rescue RSolr::Error::Http, RSolr::Error::ConnectionRefused, Faraday::ConnectionFailed
-        # Start an isolated Solr instance when the configured test URL is not live.
-      end
-    end
-
     shared_solr_opts = {managed: true, verbose: true, persist: false, download_dir: "tmp"}
     SolrWrapper.wrap(
-      shared_solr_opts.merge(port: 8985, instance_dir: "tmp/blacklight-core-prune-stale-test")
+      shared_solr_opts.merge(port: 8986, instance_dir: "tmp/blacklight-core-prune-stale-test")
     ) do |solr_wrapper|
       solr_wrapper.with_collection(name: "blacklight-core", dir: Rails.root.join("solr", "conf").to_s) do
-        yield RSolr.connect(url: "http://127.0.0.1:8985/solr/blacklight-core")
+        yield RSolr.connect(url: "http://127.0.0.1:8986/solr/blacklight-core")
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "simplecov"
+SimpleCov.command_name ENV.fetch("SIMPLECOV_COMMAND_NAME", "Minitest")
 SimpleCov.start
 
 ENV["RAILS_ENV"] ||= "test"


### PR DESCRIPTION
## Summary

- Update GeoCombine from 0.9.2 to 0.11.0
- Preserve restricted-record indexing
- Pass `OGM_PATH` to GeoCombine harvesters
- Fix CI coverage reporting
- Isolate the stale-pruning test Solr instance

## Testing

- 38 tests, 96 assertions
- 0 failures, 0 errors
- StandardRB passes